### PR TITLE
Separated game canvas background and foreground

### DIFF
--- a/packages/eightbittr/docs/Architecture.md
+++ b/packages/eightbittr/docs/Architecture.md
@@ -28,9 +28,10 @@ const game = new MyGame({
 
 Once created, the game will have two HTML DOM elements available that you can append to a page:
 
--   `canvas`: `<canvas>` element that will be drawn to by the game.
+-   `background`: `<canvas>` element that will be drawn to whenever the background changes.
+-   `foreground`: `<canvas>` element that will drawn to each tick.
 -   `container`: `<div>` element containing:
-    -   `children`: The `canvas` as its only child.
+    -   `children`: The `background` and `foreground`.
     -   `className`: `"EightBitter"`.
     -   `styles`: The same width and height as the game.
 
@@ -119,13 +120,7 @@ public readonly groups Groups<this>;
 Its class declaration looks like:
 
 ```ts
-/**
- * Collection settings for Actor group names.
- */
 export class Groups<Game extends EightBittr> extends Section<FullScreenSaver> {
-    /**
-     * Names of known Actor groups, in drawing order.
-     */
     public readonly groupNames: string[] = [];
 }
 ```
@@ -157,13 +152,7 @@ import { Groups as GroupsBase } from "eightbittr";
 
 import { FullScreenSaver } from "../FullScreenSaver";
 
-/**
- * Collection settings for Actor group names.
- */
 export class Groups extends GroupsBase<FullScreenSaver> {
-    /**
-     * Names of known Actor groups, in drawing order.
-     */
     public readonly groupNames = ["Players", "Squares"];
 }
 ```

--- a/packages/eightbittr/src/EightBittr.ts
+++ b/packages/eightbittr/src/EightBittr.ts
@@ -241,10 +241,16 @@ export class EightBittr {
     public readonly utilities: Utilities<this>;
 
     /**
-     * Canvas upon which the game's screen is constantly drawn.
+     * Background canvas upon which the game's background is occasionally drawn.
      */
     @factory(createCanvas)
-    public readonly canvas: HTMLCanvasElement;
+    public readonly background: HTMLCanvasElement;
+
+    /**
+     * Foreground canvas upon which the game's screen is constantly drawn.
+     */
+    @factory(createCanvas)
+    public readonly foreground: HTMLCanvasElement;
 
     /**
      * HTML container containing all game elements.

--- a/packages/eightbittr/src/creators/createContainer.ts
+++ b/packages/eightbittr/src/creators/createContainer.ts
@@ -2,7 +2,7 @@ import { EightBittr } from "../EightBittr";
 
 export const createContainer = (game: EightBittr) =>
     game.utilities.createElement<HTMLDivElement>("div", {
-        children: [game.canvas],
+        children: [game.background, game.foreground],
         className: "EightBitter",
         style: {
             height: `${game.settings.height}px`,

--- a/packages/eightbittr/src/creators/createPixelDrawer.ts
+++ b/packages/eightbittr/src/creators/createPixelDrawer.ts
@@ -7,9 +7,10 @@ export const createPixelDrawer = (game: EightBittr) =>
     new PixelDrawr({
         background: game.graphics.background,
         boundingBox: game.mapScreener,
-        canvas: game.canvas,
-        createCanvas: (width: number, height: number) =>
-            game.utilities.createCanvas(width, height),
+        contexts: {
+            background: game.utilities.getContext(game.background, false),
+            foreground: game.utilities.getContext(game.foreground, true),
+        },
         generateObjectKey: (actor: Actor) => game.graphics.generateActorKey(actor),
         pixelRender: game.pixelRender,
         spriteCacheCutoff: game.graphics.spriteCacheCutoff,

--- a/packages/eightbittr/src/sections/Utilities.ts
+++ b/packages/eightbittr/src/sections/Utilities.ts
@@ -82,33 +82,37 @@ export class Utilities<Game extends EightBittr> extends Section<Game> {
     }
 
     /**
-     * Creates and returns a new HTML <canvas> element with no image smooactor.
+     * Creates and returns a new HTML <canvas> element.
      *
      * @param width   How wide the canvas should be.
      * @param height   How tall the canvas should be.
+     * @param alpha  Whether to enable alpha (transparency).
      * @returns A canvas of the given width and height height.
      */
     public createCanvas(width: number, height: number): HTMLCanvasElement {
-        const canvas: HTMLCanvasElement = document.createElement("canvas");
-        const context: any = canvas.getContext("2d");
+        const canvas = document.createElement("canvas");
 
         canvas.width = width;
         canvas.height = height;
-
-        // For speed's sake, disable image smooactor in the first supported browser
-        if (typeof context.imageSmooactorEnabled !== "undefined") {
-            context.imageSmooactorEnabled = false;
-        } else if (typeof context.webkitImageSmooactorEnabled !== "undefined") {
-            context.webkitImageSmooactorEnabled = false;
-        } else if (typeof context.mozImageSmooactorEnabled !== "undefined") {
-            context.mozImageSmooactorEnabled = false;
-        } else if (typeof context.msImageSmooactorEnabled !== "undefined") {
-            context.msImageSmooactorEnabled = false;
-        } else if (typeof context.oImageSmooactorEnabled !== "undefined") {
-            context.oImageSmooactorEnabled = false;
-        }
+        canvas.style.position = "absolute";
 
         return canvas;
+    }
+
+    /**
+     * Returns a <canvas> element's 2D rendering context tuned for performance.
+     *
+     * @param canvas  <canvas> element to get a context for.
+     * @param alpha  Whether to enable alpha (transparency).
+     * @returns 2D rendering context for the element.
+     */
+    public getContext(canvas: HTMLCanvasElement, alpha: boolean): CanvasRenderingContext2D {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        const context = canvas.getContext("2d", { alpha })!;
+
+        context.imageSmoothingEnabled = false;
+
+        return context;
     }
 
     /**
@@ -309,9 +313,18 @@ export class Utilities<Game extends EightBittr> extends Section<Game> {
      *          called within a callback of a genuine user-triggered event.
      */
     public takeScreenshot(name: string, format = "image/png"): void {
+        const canvas = this.createCanvas(
+            this.game.mapScreener.width,
+            this.game.mapScreener.height
+        );
+        const context = this.getContext(canvas, true);
+
+        context.drawImage(this.game.background, 0, 0);
+        context.drawImage(this.game.foreground, 0, 0);
+
         const link: HTMLLinkElement = this.createElement("a", {
             download: name + "." + format.split("/")[1],
-            href: this.game.canvas.toDataURL(format).replace(format, "image/octet-stream"),
+            href: canvas.toDataURL(format).replace(format, "image/octet-stream"),
         });
 
         link.click();

--- a/packages/pixeldrawr/src/types.ts
+++ b/packages/pixeldrawr/src/types.ts
@@ -1,21 +1,27 @@
 import { PixelRendr } from "pixelrendr";
 
 /**
- * Create a canvas of a given width and height.
- *
- * @param width   Width of the canvas.
- * @param height   Height of the canvas.
- * @returns Canvas of the given width and height.
- */
-export type CreateCanvas = (width: number, height: number) => HTMLCanvasElement;
-
-/**
  * Generates a retrieval key for an Actor.
  *
  * @param actor   Actor to create a key from.
  * @returns Retrieval key for the Actor.
  */
 export type GenerateObjectKey = (actor: Actor) => string;
+
+/**
+ * Background and foreground contexts to draw onto.
+ */
+export interface DrawingContexts {
+    /**
+     *
+     */
+    background: CanvasRenderingContext2D;
+
+    /**
+     *
+     */
+    foreground: CanvasRenderingContext2D;
+}
 
 /**
  * Boundaries of a drawing area, commonly fulfilled by an MapScreenr.
@@ -112,24 +118,14 @@ export interface PixelDrawrSettings {
     background?: string;
 
     /**
-     * The PixelRendr used for sprite lookups and generation.
-     */
-    pixelRender: PixelRendr;
-
-    /**
-     * The bounds of the screen for bounds checking (typically an MapScreenr).
+     * The bounds of the screen for bounds checking (typically a MapScreenr).
      */
     boundingBox: BoundingBox;
 
     /**
-     * Canvas element each Actor is to be drawn on.
+     * Background and foreground contexts to draw onto.
      */
-    canvas: HTMLCanvasElement;
-
-    /**
-     * Creates a canvas of a given width and height.
-     */
-    createCanvas: CreateCanvas;
+    contexts: DrawingContexts;
 
     /**
      * Arrays of Actor[]s that are to be drawn in each refill.
@@ -137,15 +133,10 @@ export interface PixelDrawrSettings {
     actorArrays?: Actor[][];
 
     /**
-     * Whether refills should skip redrawing the background each time.
+     * An arbitrarily small minimum opacity for an Actor to be considered not
+     * completely transparent (by default, .007).
      */
-    noRefill?: boolean;
-
-    /**
-     * The maximum size of a SpriteMultiple to pre-render (by default, 0 for
-     * never pre-rendering).
-     */
-    spriteCacheCutoff?: number;
+    epsilon?: number;
 
     /**
      * How often to draw frames (by default, 1 for every time).
@@ -155,11 +146,16 @@ export interface PixelDrawrSettings {
     /**
      * Generates retrieval keys for Actors (by default, toString).
      */
-    generateObjectKey?: GenerateObjectKey;
+    generateObjectKey: GenerateObjectKey;
 
     /**
-     * An arbitrarily small minimum opacity for an Actor to be considered not
-     * completely transparent (by default, .007).
+     * The PixelRendr used for sprite lookups and generation.
      */
-    epsilon?: number;
+    pixelRender: PixelRendr;
+
+    /**
+     * The maximum size of a SpriteMultiple to pre-render (by default, 0 for
+     * never pre-rendering).
+     */
+    spriteCacheCutoff?: number;
 }

--- a/packages/pixelrendr/README.md
+++ b/packages/pixelrendr/README.md
@@ -25,10 +25,9 @@ To start, each PixelRendr keeps a global "palette" as an Array[]:
 
 ```javascript
 [
-    [0, 0, 0, 0], // transparent
-    [255, 255, 255, 255], // white
-    [0, 0, 0, 255], // black
-    // ... and so on
+    [0, 0, 0, 0],
+    [255, 255, 255, 255],
+    [0, 0, 0, 255],
 ];
 ```
 
@@ -135,9 +134,7 @@ Drawing a simple black square:
 import { memcpyU8, pixelRender } from "pixelrendr";
 
 const pixelRender = new PixelRendr({
-    paletteDefault: [
-        [0, 0, 0, 255], // black
-    ],
+    paletteDefault: [[0, 0, 0, 255]],
     library: {
         BlackSquare: "x064,",
     },
@@ -165,8 +162,8 @@ Drawing a white square using the black square's sprite as reference for a filter
 ```typescript
 const PixelRender = new PixelRendr({
     paletteDefault: [
-        [0, 0, 0, 255], // black
-        [255, 255, 255, 255], // white
+        [0, 0, 0, 255],
+        [255, 255, 255, 255],
     ],
     library: {
         BlackSquare: "x064,",

--- a/packages/pixelrendr/src/SpriteSingle.ts
+++ b/packages/pixelrendr/src/SpriteSingle.ts
@@ -69,8 +69,9 @@ export class SpriteSingle {
         canvas.height = height;
 
         const context = canvas.getContext("2d")!;
-        const imageData = context.getImageData(0, 0, width, height);
+        context.imageSmoothingEnabled = false;
 
+        const imageData = context.getImageData(0, 0, width, height);
         imageData.data.set(this.data.slice(0, Math.min(imageData.data.length, this.data.length)));
         context.putImageData(imageData, 0, 0);
 

--- a/packages/shenanigans-manager/setup/default/.circleci/config.yml
+++ b/packages/shenanigans-manager/setup/default/.circleci/config.yml
@@ -1,8 +1,5 @@
 version: 2.1
 
-orbs:
-    puppeteer: threetreeslight/puppeteer@0.1.2
-
 references:
     default_env: &default_env
         docker:
@@ -38,7 +35,6 @@ jobs:
         <<: *default_env
         steps:
             - checkout
-            - puppeteer/install
             - *restore_yarn_cache
             {{ ^shenanigans.external }}
             - run: yarn lerna bootstrap


### PR DESCRIPTION
## Overview

Splits the `.canvas` member of `GameStartr` games into a `.background` and `.foreground`. Only the foreground's context has [`alpha`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/getContext#parameters) enabled. PixelDrawr now receives them as a `contexts` settings object.

Removes a bunch of unused functions from the `PixelDrawr` public API as well as its `noRefill` setting.

### PR Checklist

-   [x] Fixes #266
-   [x] I have run this code to verify it works
-   [x] This PR includes unit tests for the code change _(in that the game still works)_
