### PR TITLE
fix: remove options title hover and correct margins

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -1,5 +1,10 @@
 {
-    "dictionaries": ["css", "html", "softwareTerms", "typescript"],
+    "dictionaries": [
+        "css",
+        "html",
+        "softwareTerms",
+        "typescript"
+    ],
     "ignorePaths": [
         "dist",
         "lib",
@@ -51,6 +56,7 @@
         "HIGHSCORE",
         "Hittr",
         "Holdr",
+        "hoverable",
         "inputwritr",
         "Inversify",
         "itemsholdr",

--- a/cspell.json
+++ b/cspell.json
@@ -1,10 +1,5 @@
 {
-    "dictionaries": [
-        "css",
-        "html",
-        "softwareTerms",
-        "typescript"
-    ],
+    "dictionaries": ["css", "html", "softwareTerms", "typescript"],
     "ignorePaths": [
         "dist",
         "lib",

--- a/examples/FullScreenSaver/src/interface/InterfaceSettings.ts
+++ b/examples/FullScreenSaver/src/interface/InterfaceSettings.ts
@@ -123,7 +123,7 @@ export const createUserWrapprSettings = ({
                 background: "#005599",
             },
             optionsList: {
-                marginBottom: "7px",
+                marginBottom: "21px",
             },
             menu: {
                 maxWidth: "385px",

--- a/packages/shenanigans-manager/setup/bootstrap/src/interface/InterfaceSettings.ts
+++ b/packages/shenanigans-manager/setup/bootstrap/src/interface/InterfaceSettings.ts
@@ -126,7 +126,7 @@ export const createUserWrapprSettings = ({
                 background: "#005599",
             },
             optionsList: {
-                marginBottom: "7px",
+                marginBottom: "21px",
             },
             menu: {
                 maxWidth: "385px",

--- a/packages/shenanigans-manager/setup/web/lib/index.css
+++ b/packages/shenanigans-manager/setup/web/lib/index.css
@@ -39,15 +39,14 @@ h1 {
   text-align: center;
 }
 
-/* General animations */
+/* Hover animations */
 
-.hoverable {
-  opacity: 0.84;
-  transition: 140ms opacity;
+.hoverable:hover::before {
+  content: "> ";
 }
 
-.hoverable:hover {
-  opacity: 1;
+.hoverable:hover::after {
+  content: "< ";
 }
 
 /* Game section */

--- a/packages/shenanigans-manager/setup/web/lib/index.css
+++ b/packages/shenanigans-manager/setup/web/lib/index.css
@@ -39,12 +39,14 @@ h1 {
   text-align: center;
 }
 
-/* Hover animations */
+/* Focus/Hover animations */
 
+.hoverable:focus::before,
 .hoverable:hover::before {
   content: "> ";
 }
 
+.hoverable:focus::after,
 .hoverable:hover::after {
   content: "< ";
 }

--- a/packages/userwrappr/README.md
+++ b/packages/userwrappr/README.md
@@ -41,7 +41,7 @@ When you call `createDisplay`, the following happen in order:
 ### Menus
 
 It's assumed that your menus will exist below your content.
-Hovering over a menu title with a mouse will open the menu the content.
+Clicking a menu title with a mouse will open the menu the content.
 
 Each menu's schema must contain a `title: string` and `options: OptionSchema[]`.
 Options will be created in top-to-bottom order within their parent menu.

--- a/packages/userwrappr/src/Bootstrapping/ClassNames.ts
+++ b/packages/userwrappr/src/Bootstrapping/ClassNames.ts
@@ -84,7 +84,7 @@ export const defaultClassNames: ClassNames = {
     menusInnerAreaFake: "menus-inner-area-fake",
     menusOuterArea: "menus-outer-area",
     menuTitle: "menu-title",
-    menuTitleButton: "menu-title-button",
+    menuTitleButton: "hoverable menu-title-button",
     menuTitleButtonFake: "menu-title-button-fake",
     option: "option",
     optionLeft: "option-left",

--- a/packages/userwrappr/src/Menus/Menu.tsx
+++ b/packages/userwrappr/src/Menus/Menu.tsx
@@ -3,7 +3,6 @@ import { useState } from "preact/hooks";
 import { MenuSchema } from "..";
 import { MenuContainer } from "./MenuContainer";
 import { MenuContext } from "./MenuContext";
-import { OpenState } from "./OpenState";
 import { Options } from "./Options/Options";
 
 export interface MenuProps {
@@ -11,10 +10,10 @@ export interface MenuProps {
 }
 
 export const Menu = ({ menu }: MenuProps) => {
-    const [open, setOpen] = useState(OpenState.Closed);
+    const [open, setOpen] = useState(false);
 
     return (
-        <MenuContext.Provider value={{ menu, open, setOpen }}>
+        <MenuContext.Provider value={{ menu, open, toggleOpen: () => setOpen(!open) }}>
             <MenuContainer>
                 <Options />
             </MenuContainer>

--- a/packages/userwrappr/src/Menus/MenuContext.tsx
+++ b/packages/userwrappr/src/Menus/MenuContext.tsx
@@ -2,12 +2,11 @@ import { createContext } from "preact";
 import { useContext } from "preact/hooks";
 
 import { MenuSchema } from "..";
-import { OpenState } from "./OpenState";
 
 export interface MenuContextType {
     menu: MenuSchema;
-    open: OpenState;
-    setOpen: (update: (open: OpenState) => OpenState) => void;
+    open: boolean;
+    toggleOpen: () => void;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-argument

--- a/packages/userwrappr/src/Menus/MenuTitle.tsx
+++ b/packages/userwrappr/src/Menus/MenuTitle.tsx
@@ -1,30 +1,15 @@
 import { useVisualContext } from "../VisualContext";
 import { useMenuContext } from "./MenuContext";
-import { OpenState } from "./OpenState";
 
 export const MenuTitle = () => {
-    const { menu, setOpen } = useMenuContext();
+    const { menu, toggleOpen } = useMenuContext();
     const { classNames, styles } = useVisualContext();
 
     return (
-        <h2
-            className={classNames.menuTitle}
-            onMouseEnter={() =>
-                setOpen((open) => {
-                    return open || OpenState.FromHover;
-                })
-            }
-            style={styles.menuTitle}
-        >
+        <h2 className={classNames.menuTitle} style={styles.menuTitle}>
             <button
                 className={classNames.menuTitleButton}
-                onClick={() =>
-                    setOpen((open) => {
-                        return open === OpenState.FromClick
-                            ? OpenState.Closed
-                            : OpenState.FromClick;
-                    })
-                }
+                onClick={toggleOpen}
                 role="button"
                 style={styles.menuTitleButton}
             >
@@ -33,3 +18,5 @@ export const MenuTitle = () => {
         </h2>
     );
 };
+
+console.log("uhh");

--- a/packages/userwrappr/src/Menus/MenuTitle.tsx
+++ b/packages/userwrappr/src/Menus/MenuTitle.tsx
@@ -18,5 +18,3 @@ export const MenuTitle = () => {
         </h2>
     );
 };
-
-console.log("uhh");

--- a/packages/userwrappr/src/Menus/OpenState.ts
+++ b/packages/userwrappr/src/Menus/OpenState.ts
@@ -1,5 +1,0 @@
-export enum OpenState {
-    Closed = 0,
-    FromHover,
-    FromClick,
-}

--- a/packages/userwrappr/src/Menus/Options/Options.tsx
+++ b/packages/userwrappr/src/Menus/Options/Options.tsx
@@ -1,6 +1,5 @@
 import { useVisualContext } from "../../VisualContext";
 import { useMenuContext } from "../MenuContext";
-import { OpenState } from "../OpenState";
 import { ActionOption } from "./ActionOption";
 import { BooleanOption } from "./BooleanOption";
 import { MultiSelectOption } from "./MultiSelectOption";
@@ -20,19 +19,11 @@ const storeComponents = new Map<OptionType, OptionComponent>([
 ]);
 
 export const Options = () => {
-    const { menu, setOpen } = useMenuContext();
+    const { menu } = useMenuContext();
     const { classNames, containerSize, styles } = useVisualContext();
 
     return (
-        <div
-            className={classNames.options}
-            onMouseLeave={() =>
-                setOpen((open) => {
-                    return open === OpenState.FromHover ? OpenState.Closed : open;
-                })
-            }
-            style={styles.options}
-        >
+        <div className={classNames.options} style={styles.options}>
             <div
                 className={classNames.optionsList}
                 style={{


### PR DESCRIPTION
## Overview

Removes hovering from menu options, so it's only workable for clicks.

Tweaks the hover effect (and makes it used, now!) so it's `> ... <` before+after pseudo elements.

Tweaks options padding to fix #296 specifically.

### PR Checklist

-   [x] Fixes #186; fixes #296
-   [x] I have run this code to verify it works
-   [x] This PR includes unit tests for the code change
