### PR TITLE
Update 2. Actors.md

### DIFF
--- a/docs/walkthrough/2. Actors.md
+++ b/docs/walkthrough/2. Actors.md
@@ -157,7 +157,7 @@ That command should have printed a few properties a new Actor to the console.
 You can also find that new Actor in the game's `GroupHoldr`:
 
 ```ts
-FSS.groupHolder.groups.Solid[0];
+FSS.groupHolder.groups.Squares[0];
 ```
 
 Next up, we'll want to place that square in the center of the screen.


### PR DESCRIPTION
## Overview

What does this PR do? Why?
Per @JoshuaKGoldberg: The GroupHoldr module stores actors in groups based on their `.groupType` property. `groupType: "Squares"` in the `Objects` section should be what sets it. 
Let's update `Solid` to `Squares` so that we can access the new Actor.

### PR Checklist

-   [ ] Fixes #
-   [ ] I have run this code to verify it works
-   [ ] This PR includes unit tests for the code change
