### PR TITLE
feat: flesh out README.md Development sections

### DIFF
--- a/packages/shenanigans-manager/setup/readme/Development.md
+++ b/packages/shenanigans-manager/setup/readme/Development.md
@@ -12,12 +12,20 @@ yarn run compile
 ```
 
 -   `yarn run hydrate` creates a few auto-generated setup files locally.
--   `yarn run compile` builds source code with TypeScript
+-   `yarn run compile` builds source code to `lib/` with TypeScript
+
+> Tip: run `yarn compile -w` to keep TypeScript running in watch mode, so your output files stay up-to-date as you save source code.
 {{ /shenanigans.external }}
 {{ ^shenanigans.external }}
 This repository is a portion of the [EightBittr monorepo](https://raw.githubusercontent.com/FullScreenShenanigans/EightBittr).
 See its [docs/Development.md](../../docs/Development.md) for details on how to get started. 💖
 {{ /shenanigans.external }}
+{{ #shenanigans.game }}
+
+### Running Locally
+
+Once you've run the setup commands above, `lib/index.html` will contain a working file you can directly open in a browser locally, such as with `open lib/index.html` on Mac or `start lib/index.html` on Windows.
+{{ /shenanigans.game }}
 
 ### Running Tests
 
@@ -29,6 +37,18 @@ Tests are written in [Mocha](https://github.com/mochajs/mocha) and [Chai](https:
 Their files are written using alongside source files under `src/` and named `*.test.ts?`.
 Whenever you add, remove, or rename a `*.test.t*` file under `src/`, `watch` will re-run `yarn run test:setup` to regenerate the list of static test files in `test/index.html`.
 You can open that file in a browser to debug through the tests, or run `yarn test:run` to run them in headless Chrome.
+{{ #shenanigans.dist }}
+
+### Production Builds
+
+```shell
+yarn run dist
+```
+
+After running the `dist` command, the `dist/` folder will contain project outputs optimized for running in production: i.e. versions of code that are concatenated into fewer files and minified.
+`dist/index.html` will be a more optimized version of `lib/index.html`.
+
+{{ /shenanigans.dist}}
 
 <!-- Maps -->
 <!-- /Maps -->

--- a/packages/shenanigans-manager/src/commands/hydrateReadme.ts
+++ b/packages/shenanigans-manager/src/commands/hydrateReadme.ts
@@ -20,7 +20,14 @@ export const replaceBetween = async (
     const ender = `<!-- /${section} -->`;
 
     const start = readmeContents.indexOf(starter) + starter.length;
+    if (start === starter.length - 1) {
+        throw new Error(`Could not find '${starter}' in README.md.`);
+    }
+
     const end = readmeContents.indexOf(ender);
+    if (end === -1) {
+        throw new Error(`Could not find '${ender}' in README.md.`);
+    }
 
     const templateLocation = path.join(templateDir, `${section}.md`);
     const template = (await fs.readFile(templateLocation)).toString().trim();


### PR DESCRIPTION
## Overview

Adds more info to the _Development_ section of generated README.mds. Also adds error throwing if the `<!-- Development -->` comments aren't found. That was tripping up ChooseYourFramework's README.md.

Corresponds to https://github.com/JoshuaKGoldberg/ChooseYourFramework/pull/29.

### PR Checklist

-   [x] Fixes #336 
-   [x] I have run this code to verify it works
-   [x] This PR includes unit tests for the code change
